### PR TITLE
(temporarily) allow new client as origin for login.airmash.online

### DIFF
--- a/servers/login.js
+++ b/servers/login.js
@@ -25,7 +25,8 @@ const port = 4444;
 
 const permittedOrigins = [ 
   'https://airmash.online',
-  'https://test.airmash.online'
+  'https://test.airmash.online',
+  'https://spatiebot.github.io'
 ];
 
 /*


### PR DESCRIPTION
I'm working on login in the [new client](https://spatiebot.github.io/test/index.html), in [ab-client repository, branch login](https://github.com/spatiebot/ab-client/tree/login). This site is of course not allowed as origin; i'd like to add it for testing. 

For the future I'd maybe somehow merge the new frontend with the airmash-frontend repository, so players can choose between the frontends? I'm not sure. If you have thoughts about it, I'd love to hear. 